### PR TITLE
Add .scannerwork to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.scannerwork
 .sonar


### PR DESCRIPTION
Because the ITs add a .scannerwork folder in the projects, the `its/sources` folder in the apex analyzer are displayed as modified by git.
This change should remove unnecessary noise from the `git status` output